### PR TITLE
Update autocomplete_inputdialog.py

### DIFF
--- a/qtodotxt/ui/controls/autocomplete_inputdialog.py
+++ b/qtodotxt/ui/controls/autocomplete_inputdialog.py
@@ -43,7 +43,7 @@ class AutoCompleteInputDialog(QtGui.QDialog):
         today = 'due:' + date.today().strftime('%Y-%m-%d')
         tomorrow = 'due:' + (date.today() + timedelta(days=1)).strftime('%Y-%m-%d')
         EOW = 'due:' + (date.today() + timedelta((6-date.today().weekday()) % 7)).strftime('%Y-%m-%d')
-        EOM = 'due:' + (date.today().replace(month=date.today().month+1, day=1)
+        EOM = 'due:' + ((date.today().replace(day=1) + timedelta(days=32)).replace(day=1)
                         - timedelta(days=1)).strftime('%Y-%m-%d')
         EOY = 'due:' + (date.today().replace(year=date.today().year+1, month=1, day=1)
                         - timedelta(days=1)).strftime('%Y-%m-%d')


### PR DESCRIPTION
Avoid error:
    ValueError: month must be in 1..12
Solution from: http://stackoverflow.com/a/23447523